### PR TITLE
fix: Entries not sorted properly in files tab

### DIFF
--- a/templates/components/files.html
+++ b/templates/components/files.html
@@ -3,7 +3,7 @@
   {%- set root_section = get_section(path="_index.md") -%}
   {% set_global tabindex = -1 %}
 
-  {% set pages = root_section.pages | sort(attribute="title")%}
+  {% set pages = root_section.pages %}
   {%- for p in pages %}
   {%- set_global tabindex = tabindex - 1 -%}
   <li class="file">
@@ -24,7 +24,7 @@
 
 {% if root_section.subsections %}
 
-{% set subsections = root_section.subsections | sort(attribute="") %}
+{% set subsections = root_section.subsections %}
 {%- for s in subsections -%}
   {%- set s = get_section(path=s) -%}
 
@@ -42,7 +42,7 @@
     </span>
 
     <ul>
-      {% set pages = s.pages | sort(attribute="title")%}
+      {% set pages = s.pages %}
       {% for p in pages -%}
       <li class="file">
         <span>└──
@@ -54,7 +54,7 @@
       </li>
       {%- endfor -%}
 
-      {% set subsections = s.subsections | sort(attribute="") %}
+      {% set subsections = s.subsections %}
         {% if subsections %}
         {% for s in subsections -%}
           {% set s = get_section(path=s) -%}
@@ -80,7 +80,7 @@
 
   <ul>
 
-  {% set pages = root_section.pages | sort(attribute="title")%}
+  {% set pages = root_section.pages %}
   {% for p in pages -%}
   <li class="file">
     <span>└──


### PR DESCRIPTION
Hi and thanks for this pretty theme, I love it!

So I was wondering why my posts were not sorted by date in the `files` section to the left (as that's what I have configured in the `_index.md` of each folder).

I am new to zola templates, so I just deleted every `sort` filter I found in hopes it would fix my issue.

It did.

So here are my naive proposed changes. Please tell me which of these `sort`s are actually essential (and why!) as I cannot see any difference in ordering elsewhere.

Edit: Actually, I see a difference in root entries, so I guess the `sort(attribute="title")` should stay

<img width="686" height="358" alt="zola-neovim-sorting" src="https://github.com/user-attachments/assets/ed42dddf-b744-4eb4-abe9-78d73d37be3e" />
